### PR TITLE
If no INPUT_IMAGE_NAME then ensure repo name is lowercase

### DIFF
--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -30,6 +30,8 @@ fi
 # Set image name to username/repo_name if not provided
 if [ -z "$INPUT_IMAGE_NAME" ]; then
     INPUT_IMAGE_NAME="$INPUT_DOCKER_USERNAME/$REPO_NAME"
+    # Lower-case
+    INPUT_IMAGE_NAME="${INPUT_IMAGE_NAME,,}"
 fi
 
 # Prepend image name with registry if it is supplied


### PR DESCRIPTION
Hopefully fixes https://discourse.jupyter.org/t/how-to-build-mybinder-image-automatically-at-each-commit/538 with a bit of [bash magic](https://stackoverflow.com/a/2264537)