### PR TITLE
Patch readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ jobs:
       with: # make sure username & password matches your registry
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKER_REGISTRY: "containers.pkg.github.com"
+        DOCKER_REGISTRY: "docker.pkg.github.com"
 ```
 
 ## Change Image Name

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ on: push
 
 jobs:
   binder:
+    runs-on: ubuntu-latest
+    steps:
     - name: Checkout Code
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Faced with a couple of problems successfully copying incorrect snippets.

1. Missed indication of the type of machine on which the job will be performed in [this section](https://github.com/jupyterhub/repo2docker-action#use-github-actions-to-cache-the-build-for-binderhub).
2. There is no such registry `containers.pkg.github.com`. If you meant the GitHub Packages registry as an example, then it should be `docker.pkg.github.com`.

Picture 1

![](https://i.imgur.com/bhGNjDV.png)

Picture 2

![](https://i.imgur.com/4N0vS5b.png)