### PR TITLE
Add `REPO_DIR` input for setting `--target-repo-dir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ See the [examples](#examples) section is very helpful for understanding the inpu
 
 - **`NOTEBOOK_USER`**:
     description: username of the primary user in the image. If this is not specified, this is set to `joyvan`.  **NOTE**: This value is also overriden with `jovyan` if the parameters `BINDER_CACHE` or `MYBINDERORG_TAG` are provided.
+- **`REPO_DIR`**:
+    Path inside the image where contents of the repositories are copied to, and where all the build operations (such as postBuild) happen. Defaults to `/home/<NOTEBOOK_USER>` if not set.
 - **`IMAGE_NAME`**:
     name of the image.  Example - myusername/myContainer.  If not supplied, this defaults to `<DOCKER_USERNAME/GITHUB_REPOSITORY_NAME>`.
 - **`DOCKER_REGISTRY`**:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   NOTEBOOK_USER:
     description: username of the primary user in the image
     require: false
+  REPO_DIR:
+    description: path inside the image where contents of the repositories are copied to
+    require: false
   LATEST_TAG_OFF:
     description: Setting this variable to any value will prevent your image from being tagged with `latest`, in additiona to the GitHub commit SHA.  This is enabled by default.
     require: false

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -54,7 +54,6 @@ fi
 if [ -z "$INPUT_REPO_DIR" ];
     then
         REPO_DIR="/home/${NB_USER}"
-
     else
         REPO_DIR="${INPUT_REPO_DIR}"
 fi

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -49,6 +49,16 @@ if [ -z "$INPUT_NOTEBOOK_USER" ] || [ "$INPUT_MYBINDERORG_TAG" ] || [ "$INPUT_BI
         NB_USER="${INPUT_NOTEBOOK_USER}"
 fi
 
+# Set REPO_DIR
+
+if [ -z "$INPUT_REPO_DIR" ];
+    then
+        REPO_DIR="/home/${NB_USER}"
+
+    else
+        REPO_DIR="${INPUT_REPO_DIR}"
+fi
+
 # Set Local Variables
 shortSHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
 SHA_NAME="${INPUT_IMAGE_NAME}:${shortSHA}"
@@ -63,6 +73,7 @@ echo "::group::Show Variables"
     echo "SHA_NAME: ${SHA_NAME}"
     echo "PWD: ${PWD}"
     echo "INPUT_NOTEBOOK_USER: ${INPUT_NOTEBOOK_USER}"
+    echo "INPUT_REPO_DIR: ${INPUT_REPO_DIR}"
     echo "INPUT_IMAGE_NAME: ${INPUT_IMAGE_NAME}"
     echo "DOCKER_REGISTRY": ${INPUT_DOCKER_REGISTRY}
     echo "INPUT_MYBINDERORG_TAG: ${INPUT_MYBINDERORG_TAG}"
@@ -103,7 +114,7 @@ if [ -z "$INPUT_NO_PUSH" ]; then
             fi
         fi
 
-        jupyter-repo2docker --push --no-run --user-id 1000 --user-name ${NB_USER} --image-name ${SHA_NAME} --cache-from ${INPUT_IMAGE_NAME} ${PWD}
+        jupyter-repo2docker --push --no-run --user-id 1000 --user-name ${NB_USER} --target-repo-dir ${REPO_DIR} --image-name ${SHA_NAME} --cache-from ${INPUT_IMAGE_NAME} ${PWD}
 
         if [ -z "$INPUT_LATEST_TAG_OFF" ]; then
             docker tag ${SHA_NAME} ${INPUT_IMAGE_NAME}:latest
@@ -133,7 +144,7 @@ if [ -z "$INPUT_NO_PUSH" ]; then
 
 else
     echo "::group::Build Image Without Pushing" 
-        jupyter-repo2docker --no-run --user-id 1000 --user-name ${NB_USER} --image-name ${SHA_NAME} --cache-from ${INPUT_IMAGE_NAME} ${PWD}
+        jupyter-repo2docker --no-run --user-id 1000 --user-name ${NB_USER} --target-repo-dir ${REPO_DIR} --image-name ${SHA_NAME} --cache-from ${INPUT_IMAGE_NAME} ${PWD}
         if [ -z "$INPUT_LATEST_TAG_OFF" ]; then
             docker tag ${SHA_NAME} ${INPUT_IMAGE_NAME}:latest
         fi


### PR DESCRIPTION
This PR adds a new input named `REPO_DIR` for setting [--target-repo-dir](https://repo2docker.readthedocs.io/en/latest/usage.html?highlight=target-repo-dir#cmdoption-jupyter-repo2docker-target-repo-dir) option when running `repo2docker`.

Personally, I needed this to let my image have separate `REPO_DIR` and `HOME` for customization and easier mounting of persistent user volume to home directory. Hope this make sense and also help others. By default, it's set to `/home/${NB_USER}` following the current behavior, so shouldn't give any impact on existing uses.