### PR TITLE
Update repo2docker logo image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](https://github.com/jupyterhub/repo2docker-action/workflows/Test/badge.svg) [![MLOps](https://img.shields.io/badge/MLOps-black.svg?logo=github&?logoColor=blue)](https://mlops-github.com)
 
 
-# <a href="https://github.com/jupyter/repo2docker"><img src="https://raw.githubusercontent.com/jupyter/repo2docker/3fa7444fca6ae2b51e590cbc9d83baf92738ca2a/docs/source/_static/images/repo2docker.png" height="40px" /></a>  repo2docker GitHub Action
+# <a href="https://github.com/jupyterhub/repo2docker"><img src="https://raw.githubusercontent.com/jupyterhub/repo2docker/71eb8058c790a88d223470a55f3ea5b744614dcf/docs/source/_static/images/repo2docker.png" height="40px" /></a>  repo2docker GitHub Action
 
 
 <!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->


### PR DESCRIPTION
This PR updates the `repo2docker` logo image location so that it's properly rendered in the README. In particular the new link points to the `jupyterhub` GitHub org and updates to the latest `repo2docker` commit hash (just updating `jupyter` -> `jupyterhub` didn't seem to work -- I'm not sure why)