### PR TITLE
Remove redundant chmod of trigger_binder.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apk add curl
 COPY create_docker_image.sh /create_docker_image.sh
 COPY binder_cache.py /binder_cache.py
 COPY trigger_binder.sh /trigger_binder.sh
-RUN chmod u+x trigger_binder.sh
 
 ENTRYPOINT ["/bin/bash", "/create_docker_image.sh"]
 


### PR DESCRIPTION
trigger_binder.sh is already marked with +x on the filesystem,
so does not need this extra line in the Dockerfile