### PR TITLE
Enable better error handling in ./bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # THIS FILE IS FOR LOCAL TESTING
 


### PR DESCRIPTION
In particular, this will error with an informative
message when DOCKER_USERNAME and DOCKER_PASSWORD is not
set