### PR TITLE
fix regression that makes DOCKER_UESRNAME required sometimes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,5 +39,4 @@ jobs:
       uses: ./
       with:
         NO_PUSH: true
-        DOCKER_USERNAME: ${{ github.actor }}
         MYBINDERORG_TAG: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See the [examples](#examples) section is very helpful for understanding the inpu
 - **`DOCKER_REGISTRY`**:
     description: domain name of the docker registry.  If not supplied, this defaults to [DockerHub](https://hub.docker.com/)
 - **`IMAGE_NAME`**:
-    name of the image.  Example - myusername/myContainer.  If not supplied, this defaults to `<DOCKER_USERNAME>/<GITHUB_REPOSITORY_NAME>`.
+    name of the image.  Example - myusername/myContainer.  If not supplied, this defaults to `<DOCKER_USERNAME>/<GITHUB_REPOSITORY_NAME>` or `<GITHUB_ACTOR>/<GITHUB_REPOSITORY_NAME>`.
 - **`NOTEBOOK_USER`**:
     description: username of the primary user in the image. If this is not specified, this is set to `joyvan`.  **NOTE**: This value is also overriden with `jovyan` if the parameters `BINDER_CACHE` or `MYBINDERORG_TAG` are provided.
 - **`REPO_DIR`**:

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: domain name of the docker registry.  If not supplied, this defaults to registry.hub.docker.com.
     require: false
   IMAGE_NAME:
-    description: name of the image.  Example - myusername/myContainer.  If not supplied, this defaults to $DOCKER_USERNAME/$GITHUB_REPOSITORY_NAME
+    description: name of the image.  Example - myusername/myContainer.  If not supplied, this defaults to $DOCKER_USERNAME/$GITHUB_REPOSITORY_NAME or $GITHUB_ACTOR/$GITHUB_REPOSITORY_NAME.
     require: false
   NOTEBOOK_USER:
     description: username of the primary user in the image

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -25,14 +25,14 @@ fi
 
 REPO_NAME=`echo $GITHUB_REPOSITORY | cut -d "/" -f 2`
 
-# Set image name to username/repo_name if not provided
+# Set image name to username/repo_name or github_actor/repo_name
 if [ -z "$INPUT_IMAGE_NAME" ]; then
     if [[ -z "$INPUT_DOCKER_USERNAME" ]]; then
-        echo "IMAGE_NAME must be explicitly set when DOCKER_USERNAME isn't set.  Exiting..."
-        exit 1
+        INPUT_IMAGE_NAME="$GITHUB_ACTOR/$REPO_NAME"
+    else
+        INPUT_IMAGE_NAME="$INPUT_DOCKER_USERNAME/$REPO_NAME"
     fi
 
-    INPUT_IMAGE_NAME="$INPUT_DOCKER_USERNAME/$REPO_NAME"
     # Lower-case
     INPUT_IMAGE_NAME="${INPUT_IMAGE_NAME,,}"
 fi


### PR DESCRIPTION
Closes #74 by reverting a change in #73 and making sure that the behavior that was undocumented now is documented.

I consider this fix quite critical to fix because we have no release system so I assume many use `@master`, which will make their use of this action break.