### PR TITLE
Add release automation and documentation

### DIFF
--- a/.github/workflows/release-updates.yaml
+++ b/.github/workflows/release-updates.yaml
@@ -1,0 +1,23 @@
+# Automatically updates "vX" branches based on GitHub releases. To cut a new
+# release, use the GitHub UI where you enter a tag name and release name of
+# "vX.Y.Z". See https://github.com/jupyterhub/repo2docker-action/releases.
+---
+name: Release updates
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      # Action reference: https://github.com/Actions-R-Us/actions-tagger
+      - uses: Actions-R-Us/actions-tagger@f411bd910a5ad370d4511517e3eac7ff887c90ea
+        with:
+          # By using branches as identifiers it is still possible to backtrack
+          # some patch, but not if we use tags.
+          prefer_branch_releases: true
+          token: "${{ github.token }}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+# Making a release
+
+Releases are automated through
+[.github/workflows/release-updates.yaml](https://github.com/jupyterhub/repo2docker-action/blob/HEAD/.github/workflows/release-updates.yaml).
+
+To cut a release, visit the projects [releases
+page](https://github.com/jupyterhub/repo2docker-action/releases) where
+you create a new GitHub release. Enter a _tag name_ and _release name_ of
+"vX.Y.Z". Doing so will automatically update the "vX" branch allowing users to
+reference this action with `jupyterhub/repo2docker-action@vX`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,3 +8,6 @@ page](https://github.com/jupyterhub/repo2docker-action/releases) where
 you create a new GitHub release. Enter a _tag name_ and _release name_ of
 "vX.Y.Z". Doing so will automatically update the "vX" branch allowing users to
 reference this action with `jupyterhub/repo2docker-action@vX`.
+
+If you are to cut a major release, make sure to also update references to the
+`@vX` branch to the `@vX+1` branch.


### PR DESCRIPTION
This PR aligns this repository that contains a GitHub action definition with some practices for the other repositories in the jupyterhub org that also defines GitHub actions.

With this in place and a new release made, we can also update the readme to suggest referencing `@v1` or similar rather than `@master`.