### PR TITLE
Use repo2docker image from Quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/repo2docker:master
+FROM quay.io/jupyterhub/repo2docker:main
 
 
 RUN echo "**** install Python ****" && \


### PR DESCRIPTION
It came to my attention that repo2docker-action has been stuck with an old version ([2021.03.0-70.g43891a6](https://hub.docker.com/layers/jupyter/repo2docker/2021.03.0-70.g43891a6/images/sha256-b17d42ae1526c56c21e2d969c65b0ca367664310a2e68e197384e04070c60e51)) of repo2docker since mid-July. Seems like upstream has decided to migrate to Quay.io leaving Docker Hub: jupyterhub/repo2docker#1076