### PR TITLE
Set output image name unconditionally

### DIFF
--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -87,6 +87,8 @@ echo "::group::Show Variables"
     echo "SHA_NAME: ${SHA_NAME}"
 echo "::endgroup::"
 
+echo "::set-output name=IMAGE_SHA_NAME::${SHA_NAME}"
+
 if [ -z "$INPUT_NO_PUSH" ]; then
     echo "::group::Build and Push ${SHA_NAME}"
         


### PR DESCRIPTION
Earlier, we were only setting it if we pushed the image