### PR TITLE
Use docker push to push image

### DIFF
--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -120,38 +120,6 @@ if [ "$INPUT_ADDITIONAL_TAG" ]; then
 fi
 echo "::endgroup::"
 
-if [ -z "$INPUT_NO_PUSH" ]; then
-    echo "::group::Pushing ${SHA_NAME}"
-
-	docker push ${SHA_NAME}
-
-    if [ -z "$INPUT_LATEST_TAG_OFF" ]; then
-        docker push ${INPUT_IMAGE_NAME}:latest
-    fi
-    if [ "$INPUT_ADDITIONAL_TAG" ]; then
-        docker push ${INPUT_IMAGE_NAME}:$INPUT_ADDITIONAL_TAG
-    fi
-
-    echo "::endgroup::"
-
-    echo "::set-output name=PUSH_STATUS::true"
-
-    if [ "$INPUT_PUBLIC_REGISTRY_CHECK" ]; then
-        echo "::group::Verify That Image Is Public"
-        docker logout
-        if docker pull $SHA_NAME; then
-            echo "Verified that $SHA_NAME is publicly visible."
-        else
-            echo "Could not pull docker image: $SHA_NAME.  Make sure this image is public before proceeding."
-            exit 1
-        fi
-        echo "::endgroup::"
-    fi
-
-else
-    echo "::set-output name=PUSH_STATUS::false"
-fi
-
 # If a directory named image-tests exists, run tests on the built image
 if [ -d "${PWD}/image-tests" ]; then
     echo "::group::Run tests found in image-tests/"
@@ -182,6 +150,38 @@ if [ -d "${PWD}/image-tests" ]; then
         py.test ${PYTEST_FLAGS} image-tests/
     '
     echo "::endgroup::"
+fi
+
+if [ -z "$INPUT_NO_PUSH" ]; then
+    echo "::group::Pushing ${SHA_NAME}"
+
+	docker push ${SHA_NAME}
+
+    if [ -z "$INPUT_LATEST_TAG_OFF" ]; then
+        docker push ${INPUT_IMAGE_NAME}:latest
+    fi
+    if [ "$INPUT_ADDITIONAL_TAG" ]; then
+        docker push ${INPUT_IMAGE_NAME}:$INPUT_ADDITIONAL_TAG
+    fi
+
+    echo "::endgroup::"
+
+    echo "::set-output name=PUSH_STATUS::true"
+
+    if [ "$INPUT_PUBLIC_REGISTRY_CHECK" ]; then
+        echo "::group::Verify That Image Is Public"
+        docker logout
+        if docker pull $SHA_NAME; then
+            echo "Verified that $SHA_NAME is publicly visible."
+        else
+            echo "Could not pull docker image: $SHA_NAME.  Make sure this image is public before proceeding."
+            exit 1
+        fi
+        echo "::endgroup::"
+    fi
+
+else
+    echo "::set-output name=PUSH_STATUS::false"
 fi
 
 if [ "$INPUT_BINDER_CACHE" ]; then


### PR DESCRIPTION
docker push has a couple of advantages over --push in
repo2docker:

- If we use --push, we can not actually run the docker image-tests/
  before pushing! So if an image-test/ fails, the docker image is still
  pushed! This is very confusing behavior.
- It times out sometimes, causing issues where the image just
  fails to push after building. docker push doesn't have this
  issue - see https://github.com/2i2c-org/utoronto-image/issues/20,
  where we had to manually run a docker push.
- docker push provides more useful output than --push

This commit also removes some code duplication - we now build
the image regardless, and use the flag just to differentiate pushing.
An unused bash function was also deleted.