### PR TITLE
Provide just docker tag as an output too

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ See the [examples](#examples) section is very helpful for understanding the inpu
 
 - **`IMAGE_SHA_NAME`**
     The name of the docker image, which is tagged with the SHA.
+- **`IMAGE_SHA_TAG`**
+    The short tag used as the 'tag' part (after the `:`) of the docker image name.
 - **`PUSH_STATUS`**:
     This is `false` if `NO_PUSH` is provided or `true` otherwhise.
 

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -79,6 +79,7 @@ echo "::group::Show Variables"
 echo "::endgroup::"
 
 echo "::set-output name=IMAGE_SHA_NAME::${SHA_NAME}"
+echo "::set-output name=IMAGE_SHA_TAG::${shortSHA}"
 
 
 echo "::group::Build ${SHA_NAME}"


### PR DESCRIPTION
Very helpful when trying to auto-update helm charts,
as they take the tag and the image separately