### PR TITLE
Add Github workspace as safe directory on commit local Dockerfile for Binder cache

### DIFF
--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -187,6 +187,7 @@ fi
 if [ "$INPUT_BINDER_CACHE" ]; then
     echo "::group::Commit Local Dockerfile For Binder Cache"
     python /binder_cache.py "$SHA_NAME"
+    git config --global --add safe.directory /github/workspace
     git config --global user.email "github-actions[bot]@users.noreply.github.com"
     git config --global user.name "github-actions[bot]"
     git add binder/Dockerfile


### PR DESCRIPTION
Address Git security issue that causes Docker builds to suddenly fail. 

See https://github.com/jupyterhub/repo2docker-action/issues/89#issue-1203976137 and https://github.com/actions/checkout/issues/760