### PR TITLE
Add input to pass extra arguments to repo2docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ See the [examples](#examples) section is very helpful for understanding the inpu
     This the Git branch, tag, or commit that you want [mybinder.org](https://mybinder.org/) to proactively build from your repo.  This is useful if you wish to reduce startup time on mybinder.org.  **Your repository must be public for this work, as mybinder.org only works with public repositories**.
 - **`PUBLIC_REGISTRY_CHECK`**:
     Setting this variable to any value will validate that the image pushed to the registry is publicly visible.
+- **`REPO2DOCKER_EXTRA_ARGS`**:
+    Any extra commandline parameters to be passed to the repo2docker build command
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ inputs:
   NO_GIT_PUSH:
     description: This is a private variable that is used by the maintainers of this Action for debugging.  Setting this value to true will prevent any changes from being saved to your repository.
     require: false
+  REPO2DOCKER_EXTRA_ARGS:
+    description: Extra commandline arguments to be passed to repo2docker
+    required: false
 outputs:
   IMAGE_SHA_NAME:
     description: The name of the docker image, which is tagged with the SHA.

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -109,9 +109,11 @@ if [ "$INPUT_BINDER_CACHE" ]; then
 fi
 
 # Just build the image, do not push it
+# Don't quote ${INPUT_REPO2DOCKER_EXTRA_ARGS}, as it *should* be interpreted as arbitrary
+# arguments to be passed to repo2docker
 jupyter-repo2docker --no-run --user-id 1000 --user-name ${NB_USER} \
     --target-repo-dir ${REPO_DIR} --image-name ${SHA_NAME} --cache-from ${INPUT_IMAGE_NAME} \
-    --appendix "$APPENDIX" ${PWD}
+    --appendix "$APPENDIX" ${INPUT_REPO2DOCKER_EXTRA_ARGS} ${PWD}
 
 if [ -z "$INPUT_LATEST_TAG_OFF" ]; then
     docker tag ${SHA_NAME} ${INPUT_IMAGE_NAME}:latest


### PR DESCRIPTION
Acts as a useful 'escape hatch' for specifying any repo2docker params we don't already have a parameter for.