### PR TITLE
Change to python3 to run Binder cache script

### DIFF
--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -195,7 +195,7 @@ fi
 
 if [ "$INPUT_BINDER_CACHE" ]; then
     echo "::group::Commit Local Dockerfile For Binder Cache"
-    python /binder_cache.py "$SHA_NAME"
+    python3 /binder_cache.py "$SHA_NAME"
     git config --global --add safe.directory /github/workspace
     git config --global user.email "github-actions[bot]@users.noreply.github.com"
     git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
I started getting this error:

```
Commit Local Dockerfile For Binder Cache
  /create_docker_image.sh: line 198: python: command not found
```

So I changed `python` to `python3` and it worked again. I don't know what might have changed to cause this error, but it seems like a harmless fix?