### PR TITLE
Specify repo and ref as a docker label

### DIFF
--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -116,9 +116,13 @@ fi
 
 # Just build the image, do not push it
 # Don't quote ${INPUT_REPO2DOCKER_EXTRA_ARGS}, as it *should* be interpreted as arbitrary
-# arguments to be passed to repo2docker
+# arguments to be passed to repo2docker.
+# Explicitly specify repo and ref labels, as repo2docker only knows it is building something
+# local.
 jupyter-repo2docker --no-run --user-id 1000 --user-name ${NB_USER} \
     --target-repo-dir ${REPO_DIR} --image-name ${SHA_NAME} --cache-from ${INPUT_IMAGE_NAME} \
+    --label "repo2docker.repo=https://github.com/${GITHUB_REPOSITORY}" \
+    --label "repo2docker.ref=${GITHUB_REF}" \
     --appendix "$APPENDIX" ${INPUT_REPO2DOCKER_EXTRA_ARGS} ${PWD}
 
 if [ -z "$INPUT_LATEST_TAG_OFF" ]; then


### PR DESCRIPTION
repo2docker triest to set these labels automatically, but because we call repo2docker on the local checkout, it doesn't know where the build is coming from.

If you look at a built image, right now you get:

`skopeo --override-os linux inspect  docker://quay.io/2i2c/cloudbank-data8-image:aa7e0df7adf4`

```
"Labels": {
    ...
    "repo2docker.ref": "",
    "repo2docker.repo": "local",
    "repo2docker.version": "2022.10.0+169.g6250c06"
},
```

This makes it difficult to trace the built image back to a repo.

We just explicitly set those here.