### PR TITLE
Change behaviour of NO_PUSH to be boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See the [examples](#examples) section is very helpful for understanding the inpu
 - **`ADDITIONAL_TAG`**:
     An optional string that specifies the name of an additional tag you would like to apply to the image.  Images are already tagged with the relevant [GitHub commit SHA](https://help.github.com/en/github/getting-started-with-github/github-glossary#commit).
 - **`NO_PUSH`**:
-    Setting this variable to any value will prevent any images from being pushed to a registry.  Furthermore, verbose logging will be enabled in this mode.  This is disabled by default.
+    If "true". this variable will prevent any images from being pushed to a registry. Furthermore, verbose logging will be enabled in this mode. Default value is "false".
 - **`BINDER_CACHE`**:
     Setting this variable to any value will add the file `binder/Dockerfile` that references the docker image that was pushed to the registry by this Action.  You cannot use this option if the parameter `NO_PUSH` is set.  This is disabled by default.
     - Note: This Action assumes you are not explicitly using Binder to build your dependencies (You are using this Action to build your dependencies).  If a directory `binder` with other files other than `Dockerfile` or a directory named `.binder/` is detected, this step will be aborted.  This Action does not support caching images for Binder where dependencies are defined in `binder/Dockerfile` (if you are defining your dependencies this way, you probably don't need this Action).

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -11,7 +11,7 @@ if [ "$INPUT_APPENDIX_FILE" ]; then
 fi
 
 # Login to Docker registry if about to push and credentials are passed
-if [[ -z "$INPUT_NO_PUSH" && -n "$INPUT_DOCKER_PASSWORD" && -n "$INPUT_DOCKER_USERNAME" ]]; then
+if [[ "$INPUT_NO_PUSH" = "false" && -n "$INPUT_DOCKER_PASSWORD" && -n "$INPUT_DOCKER_USERNAME" ]]; then
     echo ${INPUT_DOCKER_PASSWORD} | docker login $INPUT_DOCKER_REGISTRY -u ${INPUT_DOCKER_USERNAME} --password-stdin
 fi
 

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -165,7 +165,7 @@ if [ -d "${PWD}/image-tests" ]; then
     echo "::endgroup::"
 fi
 
-if [ -z "$INPUT_NO_PUSH" ]; then
+if [ "$INPUT_NO_PUSH" = "false" ]; then
     echo "::group::Pushing ${SHA_NAME}"
 
 	docker push ${SHA_NAME}
@@ -194,6 +194,11 @@ if [ -z "$INPUT_NO_PUSH" ]; then
     fi
 
 else
+    if [ "$INPUT_NO_PUSH" != "true" ]; then
+        echo "Error: invalid value for NO_PUSH: $INPUT_NO_PUSH. Value values are true or false."
+        exit 1
+    fi
+
     echo "PUSH_STATUS=false" >> $GITHUB_OUTPUT
 fi
 

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -10,6 +10,11 @@ if [ "$INPUT_APPENDIX_FILE" ]; then
     echo "Appendix read from $INPUT_APPENDIX_FILE:\n$APPENDIX"
 fi
 
+# Set INPUT_NO_PUSH to false if it is not provided
+if [ -z "$INPUT_NO_PUSH" ]; then
+    INPUT_NO_PUSH="false"
+fi
+
 # Login to Docker registry if about to push and credentials are passed
 if [[ "$INPUT_NO_PUSH" = "false" && -n "$INPUT_DOCKER_PASSWORD" && -n "$INPUT_DOCKER_USERNAME" ]]; then
     echo ${INPUT_DOCKER_PASSWORD} | docker login $INPUT_DOCKER_REGISTRY -u ${INPUT_DOCKER_USERNAME} --password-stdin


### PR DESCRIPTION
I have been trying to use this variable in GitHub Actions like so:

```
NO_PUSH: ${ github.event_name == 'pull_request' }}
```

i.e. a build triggered by a PR would not be pushed to a registry, but a build triggered by a push to main (or whatever other events are configured by the workflow) would be pushed, which I believe is a pretty common use case.

I was surprised that this didn't work and my builds were never pushed to a registry on either trigger, and I realised this is because the action only checks if `NO_PUSH` is not empty rather than treating it like a boolean. The only way to get the desired behaviour would be to have two workflow files that are identical other than the one triggered by a PR has `NO_PUSH` set. You can see this in the `build.yaml` and `test.yaml` files here: https://github.com/2i2c-org/hub-user-image-template/tree/main/.github/workflows

This PR changes the behaviour of `NO_PUSH` to be more boolean and allows us to achieve the desired workflow in a single workflow file and without duplicating code.