### PR TITLE
Avoid version of docker-py with a regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ RUN apk add --no-cache curl build-base python3 python3-dev py3-pip
 
 RUN python3 -m pip install --upgrade wheel setuptools
 
+# Manually downgrade version of docker-py
+# Until a fix for https://github.com/docker/docker-py/issues/3240
+# is released, we want to use an older version of docker-py
+RUN pip install 'docker<7.0'
+
 # https://stackoverflow.com/a/41651363/1695486
 RUN apk add --no-cache curl curl-dev
 COPY create_docker_image.sh /create_docker_image.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN python3 -m pip install --upgrade wheel setuptools
 # Manually downgrade version of docker-py
 # Until a fix for https://github.com/docker/docker-py/issues/3240
 # is released, we want to use an older version of docker-py
-RUN pip install 'docker<7.0'
+RUN pip install 'docker!=7.0.0'
 
 # https://stackoverflow.com/a/41651363/1695486
 RUN apk add --no-cache curl curl-dev


### PR DESCRIPTION
Brings in a fix for https://github.com/docker/docker-py/issues/3240, until docker-py is released upstream.

Ref https://github.com/jupyterhub/repo2docker-action/issues/117

EDIT: fixes #117
EDIT: closes #119