### PR TITLE
Revert "Docker run tests defined in `image-tests` as root user"

### DIFF
--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -142,7 +142,7 @@ echo "::endgroup::"
 if [ -d "${PWD}/image-tests" ]; then
     echo "::group::Run tests found in image-tests/"
     # We pass in bash that is run inside the built container, so watch out for quoting.
-    docker run -u root -w ${REPO_DIR} \
+    docker run -u 1000 -w ${REPO_DIR} \
         ${SHA_NAME} /bin/bash -c '
         export PYTEST_FLAGS="";
 


### PR DESCRIPTION
Reverts jupyterhub/repo2docker-action#111

Based on discussion in https://github.com/jupyterhub/repo2docker-action/pull/111#issuecomment-2127719200