### PR TITLE
properly redirect `ls` STDOUT/STDERR output to /dev/null when looking for notebooks in the `image-tests/` directory

### DIFF
--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -159,7 +159,7 @@ if [ -d "${PWD}/image-tests" ]; then
 
         # If there are any .ipynb files in image-tests, install pytest-notebook
         # if necessary, and set PYTEST_FLAGS so notebook tests are run.
-        ls image-tests/*.ipynb > /dev/null && \
+        ls image-tests/*.ipynb 2> /dev/null && \
             echo "Found notebooks, using pytest-notebook to run them..." && \
             export PYTEST_FLAGS="--nb-test-files ${PYTEST_FLAGS}" && \
             python3 -c "import pytest_notebook" 2> /dev/null || \

--- a/create_docker_image.sh
+++ b/create_docker_image.sh
@@ -159,7 +159,7 @@ if [ -d "${PWD}/image-tests" ]; then
 
         # If there are any .ipynb files in image-tests, install pytest-notebook
         # if necessary, and set PYTEST_FLAGS so notebook tests are run.
-        ls image-tests/*.ipynb 2> /dev/null && \
+        ls image-tests/*.ipynb &> /dev/null && \
             echo "Found notebooks, using pytest-notebook to run them..." && \
             export PYTEST_FLAGS="--nb-test-files ${PYTEST_FLAGS}" && \
             python3 -c "import pytest_notebook" 2> /dev/null || \


### PR DESCRIPTION
this is minor, but i noticed it and figured it'd be a quick and easy fix.

because `pytest_notebook` seems to be abandonware (last commits were over 3 years ago), and the latest version of `pytest` doesn't work with it, i've done some work to get basic (read: basic) notebook testing integrated in to our CI/CD.

while doing this, i noticed that the following output was in my logs:

```
Installing pytest inside the image...
ls: cannot access 'image-tests/*.ipynb': No such file or directory
```

i did a little searching, and found the offending `ls` command `create_docker_image.sh`...  it appears the intent was to squelch the output, but the current implementation will only work for STDOUT, and not STDERR.